### PR TITLE
added default number of pages for raw ingestion

### DIFF
--- a/chunker/chunk_documents_raw.py
+++ b/chunker/chunk_documents_raw.py
@@ -32,6 +32,7 @@ def chunk_document(data):
             "filepath": data['documentUrl'].split('/')[-1],
             "chunk_id": chunk.embedding_metadata['index'], # type: ignore
             "offset": chunk.embedding_metadata['offset'],  # type: ignore
+            "page": chunk.embedding_metadata['page'],  # type: ignore            
             "length": chunk.embedding_metadata['length'],  # type: ignore
             "title": chunk.title,
             "category": "default",

--- a/chunker/chunk_metadata_helper.py
+++ b/chunker/chunk_metadata_helper.py
@@ -7,9 +7,10 @@ class ChunkEmbeddingHelper():
 
     def generate_chunks_with_embedding(self, document_id, content_chunks, fieldname, sleep_interval_seconds) ->  dict:
         offset = 0
+        page = 0
         chunk_embeddings = []
         for index, (content_chunk) in enumerate(content_chunks):
-            metadata = self._generate_content_metadata(document_id, fieldname, index, content_chunk, offset)
+            metadata = self._generate_content_metadata(document_id, fieldname, index, content_chunk, offset, page)
             offset += metadata['length']
             chunk_embeddings.append(metadata)
             
@@ -18,11 +19,12 @@ class ChunkEmbeddingHelper():
             time.sleep(sleep_interval_seconds)
         return chunk_embeddings # type: ignore
 
-    def _generate_content_metadata(self, document_id, fieldname, index, content, offset):
+    def _generate_content_metadata(self, document_id, fieldname, index, content, offset, page):
         metadata = {'fieldname':fieldname}
         metadata['docid'] = document_id
         metadata['index'] = index
         metadata['offset'] = offset
+        metadata['page'] = page        
         metadata['length'] = len(content)
         metadata['embedding'] = self.text_embedder.embed_content(content)
         return metadata


### PR DESCRIPTION
Raw chunking do not have page number, what was generating the following warning during the ingestion process. 

I added a default page number (0) to avoid this warning.

![19 02 2024_11 03 06_REC](https://github.com/Azure/gpt-rag-ingestion/assets/6265211/f999691b-19e3-4539-b412-c4e721360a08)
