### PR TITLE
Fix truncating

### DIFF
--- a/embedder/text_embedder.py
+++ b/embedder/text_embedder.py
@@ -29,15 +29,25 @@ class TextEmbedder():
         return len(gpt2_tokenizer.encode(text))
 
     def clean_text(self, text, token_limit=8191):
-        # Clean up text (e.g. line breaks, )    
-        text = re.sub(r'\s+', ' ', text).strip()
-        text = re.sub(r'[\n\r]+', ' ', text).strip()
-        # Truncate text if necessary (for, ada-002 max is 8191 tokens)    
-        if self.estimate_tokens(text) > token_limit:
-            logging.warning("Token limit reached exceeded maximum length, truncating...")
-            while self.estimate_tokens(text) > token_limit:
-                text = text[:-1]
-        return text
+            # Clean up text (e.g. line breaks)
+            text = re.sub(r'\s+', ' ', text).strip()
+            text = re.sub(r'[\n\r]+', ' ', text).strip()
+
+            # Truncate text if necessary (for ada-002 max is 8191 tokens)
+            if self.estimate_tokens(text) > token_limit:
+                logging.warning("Token limit reached exceeded maximum length, truncating...")
+                step_size = 1  # Initial step size
+                iteration = 0  # Iteration counter
+
+                while self.estimate_tokens(text) > token_limit:
+                    text = text[:-step_size]
+                    iteration += 1
+                    
+                    # Increase step size exponentially every 5 iterations
+                    if iteration % 5 == 0:
+                        step_size = min(step_size * 2, 100)
+
+            return text
 
     @retry(reraise=True, wait=wait_random_exponential(min=1, max=20), stop=stop_after_attempt(6))
     def embed_content(self, text, clean_text=True, use_single_precision=True):

--- a/function_app.py
+++ b/function_app.py
@@ -13,6 +13,7 @@ class DateTimeEncoder(JSONEncoder):
 def document_chunking(req: func.HttpRequest) -> func.HttpResponse:
     import jsonschema
     import logging
+    import time
     
     logging.info('Invoked document_chunking skill.')
     try:
@@ -21,8 +22,11 @@ def document_chunking(req: func.HttpRequest) -> func.HttpResponse:
         jsonschema.validate(body, schema=get_request_schema())
 
         if body:
+            start_time = time.time()
             result = process_documents(body)
-            logging.info('Finished document_chunking skill.')
+            end_time = time.time()
+            elapsed_time = end_time - start_time
+            logging.info(f'[document_chunking] Finished document_chunking skill in {elapsed_time:.2f} seconds.')
             return func.HttpResponse(result, mimetype="application/json")
         else:
             error_message = "Invalid body."


### PR DESCRIPTION
Text processing improvement:

[`text_embedder.py`](diffhunk://#diff-39659e3e8897815846e72c80e93f18f95d0786efbee30b6ce87d9fed00514bcbL32-R49): Modified the `clean_text` function to improve the way text is truncated when it exceeds the token limit. Instead of removing one character at a time, the function now removes a variable number of characters, starting with one and doubling every five iterations, up to a maximum of 100 characters per iteration. This change should make the truncation process more efficient for long texts.