### PR TITLE
Update setup.py to use dynamic search_index_name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -503,7 +503,7 @@ def execute_setup(subscription_id, resource_group, function_app_name, search_pri
         "indexProjections": {
             "selectors": [
                 {
-                    "targetIndexName":"ragindex",
+                    "targetIndexName":f"{search_index_name}",
                     "parentKeyFieldName": "parent_id",
                     "sourceContext": "/document/chunks/*",
                     "mappings": [


### PR DESCRIPTION
Modified the targetIndexName from a fixed value of "ragindex" to use a dynamic value based on search_index_name. This change improves flexibility by allowing the index name to be adjusted according to the current search configuration.