### PR TITLE
Fix 'filename is not defined' error

### DIFF
--- a/chunking/chunker_factory.py
+++ b/chunking/chunker_factory.py
@@ -12,8 +12,7 @@ class ChunkerFactory:
     
     def __init__(self):
         docint_client = DocumentIntelligenceClient()
-        self.docint_40_api = docint_client.docint_40_api
-        logging.info(f"[chunker_factory][{filename}] Doc Int API: {self.docint_40_api}")      
+        self.docint_40_api = docint_client.docint_40_api 
 
     def get_chunker(self, extension, data):
         """


### PR DESCRIPTION
Fix 'filename is not defined' error

This pull request includes a small change to the `ChunkerFactory` class in the `chunking/chunker_factory.py` file. The change removes an unnecessary logging statement from the constructor.

* [`chunking/chunker_factory.py`](diffhunk://#diff-416384446182936ae82be2977f86fa2eb18a15dd1ae6c5ec109afa7d8efd2993L16): Removed an unnecessary logging statement from the `__init__` method of the `ChunkerFactory` class.