### PR TITLE
documentSasToken optional

### DIFF
--- a/function_app.py
+++ b/function_app.py
@@ -213,7 +213,7 @@ def _get_request_schema():
                             "type": "object",
                             "properties": {
                                 "documentUrl": {"type": "string", "minLength": 1},
-                                "documentSasToken": {"type": "string", "minLength": 1},
+                                "documentSasToken": {"type": "string"},
                                 "documentContentType": {"type": "string", "minLength": 1}
                             },
                             "required": ["documentUrl", "documentContentType"],


### PR DESCRIPTION
This pull request includes a small change to the `_get_request_schema` function in the `function_app.py` file. The change removes the `minLength` constraint from the `documentSasToken` property.

* [`function_app.py`](diffhunk://#diff-e2c0b572ad19f63b34e908d655a1c7a049e1b1fcc8171ebc48ad3b009b6b5b03L216-R216): Removed the `minLength` constraint from the `documentSasToken` property in the `_get_request_schema` function.