### PR TITLE
fix sharepoint ingestion from root folder

### DIFF
--- a/connectors/sharepoint/sharepoint_data_reader.py
+++ b/connectors/sharepoint/sharepoint_data_reader.py
@@ -138,6 +138,11 @@ class SharePointDataReader:
             '/test/test1/test2/' to access nested folders.
         :return: The formatted URL.
         """
+        # If folder_path is None, empty, or just "/" then return the root folder URL.
+        if not folder_path or folder_path.strip() == "/":
+            return f"https://graph.microsoft.com/v1.0/sites/{site_id}/drives/{drive_id}/root/"
+        
+        # Otherwise, remove any trailing slashes and format the URL for a subfolder.
         folder_path_formatted = folder_path.rstrip("/")
         return f"https://graph.microsoft.com/v1.0/sites/{site_id}/drives/{drive_id}/root:{folder_path_formatted}:/"
 

--- a/connectors/sharepoint/sharepoint_files_indexer.py
+++ b/connectors/sharepoint/sharepoint_files_indexer.py
@@ -224,7 +224,7 @@ class SharepointFilesIndexer:
             number_files = len(files) if files else 0
             logging.info(f"[sharepoint_files_indexer] Retrieved {number_files} files from SharePoint.")
         except Exception as e:
-            logging.error(f"[sharepoint_files_indexer] Failed to retrieve files: {e}")
+            logging.error(f"[sharepoint_files_indexer] Failed to retrieve files. Check your sharepoint configuration environment variables. Error: {e}")
             return
 
         if not files:

--- a/tools/doc_intelligence.py
+++ b/tools/doc_intelligence.py
@@ -48,6 +48,7 @@ class DocumentIntelligenceClient:
         self.file_extensions = [
             "pdf",
             "bmp",
+            "jpg",
             "jpeg",
             "png",
             "tiff"
@@ -100,6 +101,7 @@ class DocumentIntelligenceClient:
         extensions = {
             "pdf": "application/pdf", 
             "bmp": "image/bmp",
+            "jpg": "image/jpeg",            
             "jpeg": "image/jpeg",
             "png": "image/png",
             "tiff": "image/tiff",


### PR DESCRIPTION
This pull request includes several updates to the `connectors/sharepoint` and `tools/doc_intelligence.py` files. The changes improve URL formatting, error logging, and expand file type support.

Improvements to URL formatting:

* [`connectors/sharepoint/sharepoint_data_reader.py`](diffhunk://#diff-9ab5d6ae81fdccada185c1904c40ffa4a2d951af07fb398fda2d73cc75a71ddbR141-R145): Added logic to handle cases where `folder_path` is `None`, empty, or just "/". The function now returns the root folder URL in these cases.

Enhancements to error logging:

* [`connectors/sharepoint/sharepoint_files_indexer.py`](diffhunk://#diff-c21d5484c75bc9389aeda88e5877c59496ce26b1d8e4ef2e450c69fa05824917L227-R227): Improved the error logging message to include a suggestion to check SharePoint configuration environment variables when file retrieval fails.

Expansion of supported file types:

* [`tools/doc_intelligence.py`](diffhunk://#diff-365d56d5210217e4844791eab318d47bc0f0fd742a019f795ad06946751fffcfR51): Added support for the "jpg" file extension in the `file_extensions` list and the corresponding content type in the `_get_content_type` method. [[1]](diffhunk://#diff-365d56d5210217e4844791eab318d47bc0f0fd742a019f795ad06946751fffcfR51) [[2]](diffhunk://#diff-365d56d5210217e4844791eab318d47bc0f0fd742a019f795ad06946751fffcfR104)