### PR TITLE
chore: refresh ingestion dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 
 ## [Unreleased]
 
+### Changed
+- **Dependency refresh:** Updated ingestion runtime dependencies to `python-dotenv` 1.2.2, `PyJWT` 2.12.0, `Pillow` 12.2.0, `pypdf` 6.10.2, and `langchain-text-splitters` 1.1.2. The PDF and text chunking upgrades were validated against page counting, PDF splitting, LangChain text chunking, and document-analysis PDF auto-split smoke tests.
+- **Frontend dependency refresh:** Updated the ingestion frontend `postcss` dependency to 8.5.15 and refreshed the npm lockfile.
+
 ## [v2.3.8] - 2026-05-27
 
 ### Changed

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "clsx": "^2.1.1",
         "lucide-react": "^1.7.0",
         "next-themes": "^0.4.6",
-        "postcss": "^8.5.8",
+        "postcss": "^8.5.15",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^3.5.0",
@@ -3462,9 +3462,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -3637,9 +3637,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -3655,7 +3655,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "clsx": "^2.1.1",
     "lucide-react": "^1.7.0",
     "next-themes": "^0.4.6",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.15",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^3.5.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,17 +21,17 @@ azure-cosmos==4.5.1
 # Data handling and validation dependencies
 jsonschema
 openpyxl==3.1.5
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 requests==2.33.0
 tabulate==0.9.0
 
 # Authentication and token validation
-PyJWT==2.8.0
+PyJWT==2.12.0
 cryptography>=42.0.0
 httpx>=0.27.0
 
 # AI and NLP dependencies
-langchain-text-splitters==0.3.9
+langchain-text-splitters==1.1.2
 openai==1.55.3
 tiktoken==0.7.0
 
@@ -39,10 +39,10 @@ tiktoken==0.7.0
 tenacity==8.5.0
 
 # Image library
-Pillow==12.1.1
+Pillow==12.2.0
 
 # PDF manipulation (page counting and splitting)
-pypdf==5.4.0
+pypdf==6.10.2
 
 # Process and system utilities
 psutil==7.0.0


### PR DESCRIPTION
## Summary
- Updates python-dotenv, PyJWT, Pillow, pypdf, and langchain-text-splitters.
- Updates ingestion frontend postcss and lockfile.
- Treats pypdf/langchain-text-splitters as higher-risk dependency jumps and documents targeted validation.

## Validation
- Isolated ingestion environment loaded pypdf 6.10.2, langchain-text-splitters 1.1.2, Pillow 12.2.0, PyJWT 2.12.0, and python-dotenv 1.2.2.
- PDF page-count and split smoke produced expected part counts [2, 2, 1].
- LangChainChunker generated chunks with langchain-text-splitters 1.1.2.
- DocAnalysisChunker PDF auto-split/chunk smoke completed and preserved total page count.
- pip check passed.
- npm run build passed for the ingestion frontend.