### PR TITLE
fix: accept optional securityUserIds to stamp document ACLs (#478)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+- **Uploaded document ACLs for permission-trimmed indexes (issue #478):** `/ingest-documents` now accepts an optional `securityUserIds` array and stamps it onto each chunk's `metadata_security_user_ids` instead of always writing an empty ACL. When the search index has `permissionFilterOption` enabled, this lets the uploader retrieve their own uploaded chunks (which AI Search would otherwise trim out). Anonymous/placeholder ids are ignored, and the default empty-ACL behavior is preserved when the field is absent.
 
-All notable changes to this project will be documented in this file.  
+All notable changes to this project will be documented in this file.
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
 
 ## [v2.4.2] - 2026-05-28

--- a/main.py
+++ b/main.py
@@ -529,6 +529,19 @@ async def ingest_documents(request: Request):
     values_list = body.get("values")
     conversation_id = body.get("conversationId")
 
+    # Optional ACL: object ids of the user uploading the documents. When the
+    # search index has permissionFilterOption enabled, chunks with empty
+    # security ids are trimmed out by AI Search and the uploader can never
+    # retrieve them (issue #478). Sanitize out anonymous/placeholder values so
+    # we never stamp a meaningless acl.
+    _ACL_PLACEHOLDERS = {"", "no-auth", "anonymous", "00000000-0000-0000-0000-000000000000"}
+    raw_security_user_ids = body.get("securityUserIds") or []
+    security_user_ids = [
+        str(uid).strip()
+        for uid in raw_security_user_ids
+        if isinstance(uid, str) and str(uid).strip().lower() not in _ACL_PLACEHOLDERS
+    ]
+
     if not values_list or not isinstance(values_list, list):
         return Response("Invalid body: missing or invalid values array", status_code=400)
 
@@ -641,7 +654,7 @@ async def ingest_documents(request: Request):
                     "metadata_storage_path": parent_id,
                     "metadata_storage_name": norm_file_name,
                     "metadata_storage_last_modified": last_modified,
-                    "metadata_security_user_ids": [],
+                    "metadata_security_user_ids": list(security_user_ids),
                     "metadata_security_group_ids": [],
                     "metadata_security_rbac_scope": "",
                     "chunk_id": chunk_id,
@@ -711,6 +724,12 @@ def get_ingest_documents_request_schema():
             "conversationId": {
                 "type": "string",
                 "minLength": 1
+            },
+            "securityUserIds": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
             },
             "values": {
                 "type": "array",


### PR DESCRIPTION
## Summary
Hardening for [Azure/GPT-RAG#478](https://github.com/Azure/GPT-RAG/issues/478). `/ingest-documents` previously wrote empty `metadata_security_user_ids`; on a search index with `permissionFilterOption` enabled, AI Search trims those chunks out and the uploader can never retrieve their own upload.

## Changes
- Accept an optional `securityUserIds` array in the request body (and JSON schema).
- Sanitize out anonymous/placeholder ids (`no-auth`, `anonymous`, zero-GUID, empty).
- Stamp the sanitized ids onto each chunk's `metadata_security_user_ids`. Behavior is unchanged (empty ACL) when the field is absent, so default deployments (`permissionFilterOption=disabled`) are unaffected.

## Companion PRs
- Azure/gpt-rag-orchestrator `fix/document-upload-rag-478` (keystone retrieval fix)
- Azure/gpt-rag-ui `fix/document-upload-rag-478` (forward uploader oid)