### PR TITLE
fix: restore content understanding multimodal extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - **Uploaded document ACLs for permission-trimmed indexes (issue #478):** `/ingest-documents` now accepts an optional `securityUserIds` array and stamps it onto each chunk's `metadata_security_user_ids` instead of always writing an empty ACL. When the search index has `permissionFilterOption` enabled, this lets the uploader retrieve their own uploaded chunks (which AI Search would otherwise trim out). Anonymous/placeholder ids are ignored, and the default empty-ACL behavior is preserved when the field is absent.
+- **Content Understanding multimodal ingestion regression:** Restored the format-based figure extraction path for `MultimodalChunker` when Content Understanding is used, including PDF page/region rendering and Office embedded image extraction. This brings back the behavior released in v2.3.3 without changing the `/ingest-documents` upload ACL fix.
 
 All notable changes to this project will be documented in this file.
 This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres to [Semantic Versioning](https://semver.org/).
@@ -164,5 +165,5 @@ This format follows [Keep a Changelog](https://keepachangelog.com/) and adheres 
 ### Changed
 - Major architecture refactor to support the vNext architecture.
 
-## [v1.0.0] 
+## [v1.0.0]
 - Original version.

--- a/chunking/chunkers/multimodal_chunker.py
+++ b/chunking/chunkers/multimodal_chunker.py
@@ -33,16 +33,19 @@ class MultimodalChunker(DocAnalysisChunker):
         # _analysis_client, supported_formats, and output_content_format are
         # already set by DocAnalysisChunker based on USE_DOCUMENT_INTELLIGENCE.
 
-        # Figure extraction requires Document Intelligence (get_figure is DI-specific).
-        # When Content Understanding is used for analysis, figures won't be in the
-        # result, so figure attachment is skipped naturally.
+        # Figure extraction strategy:
+        # - DocumentIntelligenceClient: use its get_figure API.
+        # - ContentUnderstandingClient: extract figures from source document
+        #   using format-specific methods (PDF crop, DOCX/PPTX media extraction).
         if isinstance(self._analysis_client, DocumentIntelligenceClient):
             self._docint_client = self._analysis_client
+            self._use_format_extraction = False
         else:
             self._docint_client = None
+            self._use_format_extraction = True
             logging.info(
                 f"[multimodal_chunker][{self.filename}] Using ContentUnderstandingClient; "
-                f"figure extraction is not available."
+                f"figures will be extracted from source document."
             )
         self.image_container = app_config_client.get("DOCUMENTS_IMAGES_STORAGE_CONTAINER", "documents-images")
         self.storage_account_name = app_config_client.get("STORAGE_ACCOUNT_NAME", "set-storage-account-name-env-var")
@@ -93,6 +96,12 @@ class MultimodalChunker(DocAnalysisChunker):
         Returns:
             list: A list of processed document chunks.
         """
+        # 0) Normalize Content Understanding figure references.
+        #    CU returns ![caption](figures/X.Y) markdown syntax whereas the
+        #    rest of the pipeline expects <figureX.Y> tags.
+        if self._use_format_extraction:
+            self._normalize_cu_figure_references(document)
+
         # 1) Replace <figure>...</figure> with <figure{id}> in sequence
         if "figures" in document and document["figures"]:
             document["content"] = self._replace_figures_in_sequence(
@@ -109,6 +118,41 @@ class MultimodalChunker(DocAnalysisChunker):
         return chunks  # Ensure chunks are returned
 
 
+
+    def _normalize_cu_figure_references(self, document):
+        """
+        Convert Content Understanding markdown figure references
+        ``![caption](figures/X.Y)`` into ``<figureX.Y>`` tags so the
+        downstream figure-attachment logic can find them.
+
+        If the CU response did not include a structured ``figures`` list,
+        one is synthesized from the markdown references.
+        """
+        content = document.get("content", "")
+        cu_figure_pattern = re.compile(r'!\[([^\]]*)\]\(figures/(\d+(?:\.\d+)*)\)')
+
+        matches = list(cu_figure_pattern.finditer(content))
+        if not matches:
+            return
+
+        if "figures" not in document or not document["figures"]:
+            document["figures"] = []
+            seen_ids: set = set()
+            for match in matches:
+                fig_id = match.group(2)
+                if fig_id not in seen_ids:
+                    seen_ids.add(fig_id)
+                    document["figures"].append({"id": fig_id})
+
+        def _replace_fn(match):
+            return f"<figure{match.group(2)}>"
+
+        document["content"] = cu_figure_pattern.sub(_replace_fn, content)
+
+        logging.info(
+            f"[multimodal_chunker][{self.filename}] Normalized {len(matches)} CU-style "
+            f"figure reference(s). Figures in document: {len(document['figures'])}"
+        )
 
     def _replace_figures_in_sequence(self, content, figures):
         """
@@ -137,8 +181,8 @@ class MultimodalChunker(DocAnalysisChunker):
 
             # Replace everything from <figure> to </figure> with <figure{id}>
             content = (
-                content[:start_index] 
-                + f"<figure{figure_id}>" 
+                content[:start_index]
+                + f"<figure{figure_id}>"
                 + content[end_index + len("</figure>"):]
             )
 
@@ -158,7 +202,7 @@ class MultimodalChunker(DocAnalysisChunker):
         document_content = document['content']
         document_content = self._number_pagebreaks(document_content)
         text_chunks = self._chunk_content(document_content)
-        
+
         chunk_id = 0
         skipped_chunks = 0
         current_page = 1
@@ -178,7 +222,7 @@ class MultimodalChunker(DocAnalysisChunker):
                 chunk_id += 1
             else:
                 skipped_chunks += 1
-        
+
         logging.debug(f"[multimodal_chunker][{self.filename}] {len(chunks)} chunk(s) created")
         if skipped_chunks > 0:
             logging.debug(f"[multimodal_chunker][{self.filename}] {skipped_chunks} chunk(s) skipped")
@@ -188,7 +232,7 @@ class MultimodalChunker(DocAnalysisChunker):
     def _chunk_content(self, content):
         """
         Splits the document content into chunks based on the specified format and criteria.
-        
+
         Yields:
             tuple: A tuple containing:
                    (chunked_content, number_of_tokens, chunk_offset, chunk_length)
@@ -222,17 +266,46 @@ class MultimodalChunker(DocAnalysisChunker):
             logging.info(f"[multimodal_chunker][{self.filename}] No figures to attach.")
             return
 
-        result_id = document.get("result_id")
-        model_id = document.get("model_id")
-        if not result_id or not model_id:
-            logging.warning(
-                f"[multimodal_chunker][{self.filename}] Missing 'result_id' or 'model_id' in document analysis results."
-            )
-            return
+        figure_image_map = {}
+        result_id = None
+        model_id = None
+
+        if self._use_format_extraction:
+            from tools.figure_extraction import build_figure_image_map
+
+            file_bytes = self.document_bytes
+            if not file_bytes:
+                temp_path = self.data.get("documentTempFile")
+                if temp_path:
+                    with open(temp_path, "rb") as f:
+                        file_bytes = f.read()
+
+            if file_bytes:
+                figure_image_map = build_figure_image_map(
+                    file_bytes, self.extension, document["figures"]
+                )
+                logging.info(
+                    f"[multimodal_chunker][{self.filename}] Pre-extracted "
+                    f"{len(figure_image_map)} figure image(s) from source document."
+                )
+            else:
+                logging.warning(
+                    f"[multimodal_chunker][{self.filename}] No file bytes available "
+                    f"for format-based figure extraction."
+                )
+                return
+        else:
+            result_id = document.get("result_id")
+            model_id = document.get("model_id")
+            if not result_id or not model_id:
+                logging.warning(
+                    f"[multimodal_chunker][{self.filename}] Missing 'result_id' or 'model_id' in document analysis results."
+                )
+                return
 
         logging.info(
-            f"[multimodal_chunker][{self.filename}] Attaching figures to chunks using "
-            f"result_id: {result_id} and model_id: {model_id}."
+            f"[multimodal_chunker][{self.filename}] Attaching figures to chunks "
+            f"(extraction={'format-based' if self._use_format_extraction else 'DI API'})."
         )
 
         # Create a quick-access dictionary for the figures by their ID
@@ -263,18 +336,25 @@ class MultimodalChunker(DocAnalysisChunker):
                     continue
 
                 try:
-                    # 1) Check dimensions
-                    figure_area_percentage = round(self._figure_area(figure, document['pages']), 2)
-                    if figure_area_percentage <= self.minimum_figure_area_percentage:
-                        logging.warning(
-                            f"[multimodal_chunker][{self.filename}] Image for figure {figure_id} "
-                            f"has insufficient percentual area ({figure_area_percentage}). Skipping."
-                        )
-                        chunk_content = chunk_content.replace(f"<figure{figure_id}>", "")
-                        continue
+                    # 1) Check dimensions when the analysis result includes bounds.
+                    pages = document.get('pages', [])
+                    if pages and figure.get('boundingRegions'):
+                        figure_area_percentage = round(self._figure_area(figure, pages), 2)
+                        if figure_area_percentage <= self.minimum_figure_area_percentage:
+                            logging.warning(
+                                f"[multimodal_chunker][{self.filename}] Image for figure {figure_id} "
+                                f"has insufficient percentual area ({figure_area_percentage}). Skipping."
+                            )
+                            chunk_content = chunk_content.replace(f"<figure{figure_id}>", "")
+                            continue
+                    else:
+                        figure_area_percentage = None
 
                     # 2) Fetch the figure image
-                    image_binary = self._docint_client.get_figure(model_id, result_id, figure_id)
+                    if self._use_format_extraction:
+                        image_binary = figure_image_map.get(figure_id)
+                    else:
+                        image_binary = self._docint_client.get_figure(model_id, result_id, figure_id)
                     if not image_binary:
                         logging.warning(
                             f"[multimodal_chunker][{self.filename}] No image data retrieved for figure {figure_id}."
@@ -301,7 +381,7 @@ class MultimodalChunker(DocAnalysisChunker):
                     url = self._upload_figure_blob(image_binary, blob_name)
 
                     # 4) Generate caption
-                    logging.info(f"[multimodal_chunker][{self.filename}] Generating caption for figure {figure_id}. Percent area: {figure_area_percentage}")                    
+                    logging.info(f"[multimodal_chunker][{self.filename}] Generating caption for figure {figure_id}. Percent area: {figure_area_percentage}")
                     figure_caption = self._generate_caption_for_figure(
                         {
                             "id": figure_id,
@@ -323,7 +403,7 @@ class MultimodalChunker(DocAnalysisChunker):
                     )
 
 
-            # Update the chunk content with placeholders updated 
+            # Update the chunk content with placeholders updated
             chunk["content"] = chunk_content
 
             # 5) Build the combined caption string
@@ -342,17 +422,17 @@ class MultimodalChunker(DocAnalysisChunker):
                     combined_caption,
                     caption_vector
                 )
-                logging.info(f"[multimodal_chunker][{self.filename}] Attached {len(figure_urls)} figures to chunk {chunk['chunk_id']}.") 
+                logging.info(f"[multimodal_chunker][{self.filename}] Attached {len(figure_urls)} figures to chunk {chunk['chunk_id']}.")
 
     def _figure_area(self, figure: Dict, pages: List[Dict]) -> float:
         """
         Calculate the total figure area by summing the areas of all bounding regions across pages.
-        
+
         Args:
-            figure (Dict): A dictionary representing the figure with 'boundingRegions', 
+            figure (Dict): A dictionary representing the figure with 'boundingRegions',
                         where each bounding region contains 'pageNumber' and 'polygon'.
             pages (List[Dict]): A list of page dictionaries each containing 'pageNumber', 'width', and 'height'.
-        
+
         Returns:
             float: The total area of all valid bounding regions across pages.
                 Returns 0.0 if no valid bounding regions are found or an error occurs.
@@ -466,7 +546,7 @@ class MultimodalChunker(DocAnalysisChunker):
 
         # 3) Assign the caption vector to the chunk
         chunk["captionVector"] = caption_vector
-        
+
 
     def _find_chunks_for_figure(self, figure_id, chunks):
         """
@@ -533,7 +613,7 @@ class MultimodalChunker(DocAnalysisChunker):
                 "Use no more than 200 words."
             )
             caption = self.aoai_client.get_completion(
-                prompt=caption_prompt, 
+                prompt=caption_prompt,
                 image_base64=figure["image"]
             )
             if not caption:

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,8 @@ tenacity==8.5.0
 # Image library
 Pillow==12.2.0
 
-# PDF manipulation (page counting and splitting)
+# PDF manipulation (page counting, splitting, and figure extraction)
+PyMuPDF==1.25.4
 pypdf==6.10.2
 
 # Process and system utilities

--- a/tools/figure_extraction.py
+++ b/tools/figure_extraction.py
@@ -1,0 +1,200 @@
+"""
+Format-specific figure extraction utilities for the Content Understanding path.
+
+When using Content Understanding instead of Document Intelligence, the
+get_figure API is not available. These helpers extract figure images directly
+from the source document bytes using bounding-box cropping for PDFs or embedded
+media extraction for Office documents.
+"""
+
+import io
+import logging
+import zipfile
+
+
+def extract_figure_from_pdf(file_bytes: bytes, figure: dict, dpi: int = 200) -> bytes | None:
+    """Extract a figure region from a PDF page."""
+    import fitz  # PyMuPDF
+    from PIL import Image
+
+    bounding_regions = figure.get("boundingRegions", [])
+    if not bounding_regions:
+        return None
+
+    region = bounding_regions[0]
+    page_number = region.get("pageNumber", 1)
+    polygon = region.get("polygon", [])
+
+    if len(polygon) < 4:
+        return None
+
+    try:
+        doc = fitz.open(stream=file_bytes, filetype="pdf")
+        page = doc[page_number - 1]
+
+        page_w = page.rect.width
+        page_h = page.rect.height
+        max_render_px = 2500
+        max_dim_pt = max(page_w, page_h)
+        effective_dpi = min(dpi, int(max_render_px * 72 / max_dim_pt))
+        effective_dpi = max(effective_dpi, 72)
+
+        zoom = effective_dpi / 72
+        mat = fitz.Matrix(zoom, zoom)
+        pix = page.get_pixmap(matrix=mat, alpha=False)
+        img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+        doc.close()
+
+        logging.info(
+            f"[figure_extraction] Page {page_number}: rendered "
+            f"{pix.width}x{pix.height} at {effective_dpi} dpi "
+            f"(page={page_w:.0f}x{page_h:.0f} pt)"
+        )
+
+        xs = [polygon[i] * effective_dpi for i in range(0, len(polygon), 2)]
+        ys = [polygon[i] * effective_dpi for i in range(1, len(polygon), 2)]
+        left = max(0, int(min(xs)))
+        top = max(0, int(min(ys)))
+        right = min(img.width, int(max(xs)))
+        bottom = min(img.height, int(max(ys)))
+
+        if right <= left or bottom <= top:
+            logging.warning(
+                f"[figure_extraction] Invalid crop box on page {page_number}: "
+                f"({left},{top})-({right},{bottom})"
+            )
+            return None
+
+        cropped = img.crop((left, top, right, bottom))
+        logging.info(
+            f"[figure_extraction] Cropped figure to "
+            f"{cropped.width}x{cropped.height}"
+        )
+
+        buf = io.BytesIO()
+        cropped.save(buf, format="PNG")
+        return buf.getvalue()
+    except Exception as e:
+        logging.error(f"[figure_extraction] PDF figure crop failed: {e}")
+        return None
+
+
+def _extract_images_from_ooxml(file_bytes: bytes, media_prefix: str) -> list[bytes]:
+    """Extract all embedded images from an OOXML ZIP package."""
+    images = []
+    try:
+        with zipfile.ZipFile(io.BytesIO(file_bytes)) as z:
+            media_files = sorted(
+                name for name in z.namelist()
+                if name.startswith(media_prefix) and not name.endswith("/")
+            )
+            for name in media_files:
+                images.append(z.read(name))
+    except Exception as e:
+        logging.error(f"[figure_extraction] OOXML image extraction failed: {e}")
+    return images
+
+
+def _extract_all_pdf_images(file_bytes: bytes, dpi: int = 200) -> list[bytes]:
+    """Render each PDF page as an image for fallback figure mapping."""
+    import fitz  # PyMuPDF
+    from PIL import Image
+
+    images: list[bytes] = []
+    max_render_px = 2500
+    try:
+        doc = fitz.open(stream=file_bytes, filetype="pdf")
+        for page_idx, page in enumerate(doc):
+            page_w = page.rect.width
+            page_h = page.rect.height
+            max_dim_pt = max(page_w, page_h)
+            effective_dpi = min(dpi, int(max_render_px * 72 / max_dim_pt))
+            effective_dpi = max(effective_dpi, 72)
+
+            zoom = effective_dpi / 72
+            mat = fitz.Matrix(zoom, zoom)
+            pix = page.get_pixmap(matrix=mat, alpha=False)
+
+            buf = io.BytesIO()
+            img = Image.frombytes("RGB", [pix.width, pix.height], pix.samples)
+            img.save(buf, format="PNG")
+            images.append(buf.getvalue())
+
+            logging.info(
+                f"[figure_extraction] Fallback: rendered page {page_idx + 1} "
+                f"as {pix.width}x{pix.height} at {effective_dpi} dpi"
+            )
+        doc.close()
+    except Exception as e:
+        logging.error(f"[figure_extraction] PDF page rendering failed: {e}")
+    return images
+
+
+def build_figure_image_map(
+    file_bytes: bytes,
+    extension: str,
+    figures: list[dict],
+) -> dict[str, bytes]:
+    """Build a mapping of figure id to image bytes for every figure."""
+    image_map: dict[str, bytes] = {}
+
+    if extension == "pdf":
+        has_bounds = any(fig.get("boundingRegions") for fig in figures)
+        logging.info(
+            f"[figure_extraction] PDF path: {len(figures)} figures, "
+            f"has_bounds={has_bounds}"
+        )
+        if has_bounds:
+            for fig in figures:
+                fig_id = fig.get("id")
+                if not fig_id:
+                    continue
+                image_data = extract_figure_from_pdf(file_bytes, fig)
+                if image_data:
+                    image_map[fig_id] = image_data
+                else:
+                    logging.warning(
+                        f"[figure_extraction] Could not crop PDF figure {fig_id}"
+                    )
+        else:
+            all_images = _extract_all_pdf_images(file_bytes)
+            for fig in figures:
+                fig_id = fig.get("id")
+                if not fig_id:
+                    continue
+                try:
+                    page_num = int(fig_id.split(".")[0])
+                except (ValueError, IndexError):
+                    logging.warning(
+                        f"[figure_extraction] Cannot parse page from "
+                        f"figure id '{fig_id}'; skipping"
+                    )
+                    continue
+                page_idx = page_num - 1
+                if 0 <= page_idx < len(all_images):
+                    image_map[fig_id] = all_images[page_idx]
+                    logging.info(
+                        f"[figure_extraction] Mapped figure {fig_id} "
+                        f"to page {page_num} render"
+                    )
+                else:
+                    logging.warning(
+                        f"[figure_extraction] Figure {fig_id} refers to "
+                        f"page {page_num} but PDF has {len(all_images)} pages"
+                    )
+
+    elif extension == "docx":
+        all_images = _extract_images_from_ooxml(file_bytes, "word/media/")
+        for idx, fig in enumerate(figures):
+            fig_id = fig.get("id")
+            if fig_id and idx < len(all_images):
+                image_map[fig_id] = all_images[idx]
+
+    elif extension == "pptx":
+        all_images = _extract_images_from_ooxml(file_bytes, "ppt/media/")
+        for idx, fig in enumerate(figures):
+            fig_id = fig.get("id")
+            if fig_id and idx < len(all_images):
+                image_map[fig_id] = all_images[idx]
+
+    return image_map


### PR DESCRIPTION
## Summary
- Restores Content Understanding multimodal figure extraction in `MultimodalChunker`.
- Adds format-based figure extraction for PDFs and Office documents when the Document Intelligence `get_figure` API is not available.
- Preserves the `/ingest-documents` upload ACL fix by leaving `securityUserIds` handling unchanged.

## Validation
- `python -m py_compile chunking\chunkers\multimodal_chunker.py tools\figure_extraction.py`
- Deployed the fixed ingestion branch to Azure test environment `gptrag-0608261624`.
- Verified `ca-rypks3dv6mn22-dataingest` is running with 100% traffic on the active revision.
- Verified `https://ca-rypks3dv6mn22-dataingest.orangedune-b5053719.swedencentral.azurecontainerapps.io/healthz` returns `{"status":"ok"}`.
- Verified `https://ca-rypks3dv6mn22-dataingest.orangedune-b5053719.swedencentral.azurecontainerapps.io/readyz` returns `{"status":"ready"}`.

## Notes
The authenticated `/ingest-documents` smoke test could not be completed in the test environment because App Configuration only contains `RESOURCE_TOKEN`, while the current ingestion auth code expects `DATA_INGEST_APP_APIKEY` or `INGESTION_APP_APIKEY`.