### PR TITLE
feat: index blob storage custom metadata (issue #487)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Blob storage metadata indexed as `custom_metadata` (issue [#487](https://github.com/Azure/GPT-RAG/issues/487)):** The blob storage indexer now extracts every user-defined tag from `blob.metadata` (skipping reserved `metadata_security_*` keys) and stamps it onto each AI Search chunk as `custom_metadata`, a `Collection(Edm.ComplexType)` with `{key, value}` pairs. Keys are normalized to trimmed lowercase, empty or whitespace-only values are dropped, and the field is filterable and facetable so retrievers can target documents by metadata. Requires the matching `custom_metadata` field to be present in the RAG index schema (shipped in `gpt-rag` via `config/search/search.j2`).
+
 ### Fixed
 - **Uploaded document ACLs for permission-trimmed indexes (issue #478):** `/ingest-documents` now accepts an optional `securityUserIds` array and stamps it onto each chunk's `metadata_security_user_ids` instead of always writing an empty ACL. When the search index has `permissionFilterOption` enabled, this lets the uploader retrieve their own uploaded chunks (which AI Search would otherwise trim out). Anonymous/placeholder ids are ignored, and the default empty-ACL behavior is preserved when the field is absent.
 - **Content Understanding multimodal ingestion regression:** Restored the format-based figure extraction path for `MultimodalChunker` when Content Understanding is used, including PDF page/region rendering and Office embedded image extraction. This brings back the behavior released in v2.3.3 without changing the `/ingest-documents` upload ACL fix.

--- a/jobs/blob_storage_indexer.py
+++ b/jobs/blob_storage_indexer.py
@@ -35,6 +35,44 @@ _ELEVATED_API_VERSION = "2025-11-01-preview"
 # -----------------------------------------------------------------------------
 # Helpers
 # -----------------------------------------------------------------------------
+
+# Blob metadata keys reserved for ACL/security plumbing. These are stamped onto
+# dedicated typed index fields and must never leak into the generic
+# `custom_metadata` collection.
+_RESERVED_BLOB_METADATA_KEYS = frozenset({
+    "metadata_security_user_ids",
+    "metadata_security_group_ids",
+    "metadata_security_id",
+    "metadata_security_rbac_scope",
+})
+
+
+def _extract_custom_metadata(meta: Optional[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Convert a blob metadata mapping into AI Search `custom_metadata` entries.
+
+    Skips reserved security keys, normalizes keys to trimmed lowercase, and
+    drops entries with empty keys or empty/None values. Values are kept as
+    strings without further coercion so callers see exactly what was tagged.
+    """
+    if not meta:
+        return []
+
+    pairs: List[Dict[str, str]] = []
+    for raw_key, raw_value in meta.items():
+        if raw_key is None:
+            continue
+        key = str(raw_key).strip().lower()
+        if not key or key in _RESERVED_BLOB_METADATA_KEYS:
+            continue
+        if raw_value is None:
+            continue
+        value = str(raw_value).strip()
+        if not value:
+            continue
+        pairs.append({"key": key, "value": value})
+    return pairs
+
+
 def _as_datetime(value) -> Optional[datetime]:
     """Convert a value to a timezone-aware datetime, or return None."""
     if value is None:
@@ -510,6 +548,7 @@ class BlobStorageDocumentIndexer:
             # Fetch blob metadata to capture ACL info if provided
             security_user_ids: List[str] = []
             security_group_ids: List[str] = []
+            custom_metadata: List[Dict[str, str]] = []
             rbac_scope = self._get_container_rbac_scope()
             try:
                 props = await blob_client.get_blob_properties()
@@ -545,10 +584,13 @@ class BlobStorageDocumentIndexer:
                     security_group_ids,
                     field_name="metadata_security_group_ids",
                 )
+
+                custom_metadata = _extract_custom_metadata(meta)
             except Exception as _:
-                # Non-fatal: continue without security IDs
+                # Non-fatal: continue without security IDs or custom metadata
                 security_user_ids = []
                 security_group_ids = []
+                custom_metadata = []
 
             # --- Memory guard: check blob size before downloading ---
             blob_props = await blob_client.get_blob_properties()
@@ -609,6 +651,7 @@ class BlobStorageDocumentIndexer:
                     security_user_ids=security_user_ids,
                     security_group_ids=security_group_ids,
                     rbac_scope=rbac_scope,
+                    custom_metadata=custom_metadata,
                 )
                 _timings["processingSec"] = round(time.monotonic() - _t_stage, 2)
             else:
@@ -660,6 +703,7 @@ class BlobStorageDocumentIndexer:
                         security_user_ids=security_user_ids,
                         security_group_ids=security_group_ids,
                         rbac_scope=rbac_scope,
+                        custom_metadata=custom_metadata,
                     )
                     for chunk in all_chunks
                 ]
@@ -787,6 +831,7 @@ class BlobStorageDocumentIndexer:
         security_user_ids: Optional[List[str]] = None,
         security_group_ids: Optional[List[str]] = None,
         rbac_scope: str = "",
+        custom_metadata: Optional[List[Dict[str, str]]] = None,
     ) -> Dict[str, Any]:
         # Azure Search key must be unique & stable per chunk
         chunk_id = int(chunk.get("chunk_id", 0))
@@ -800,6 +845,7 @@ class BlobStorageDocumentIndexer:
             "metadata_security_user_ids": list(security_user_ids or []),
             "metadata_security_group_ids": list(security_group_ids or []),
             "metadata_security_rbac_scope": rbac_scope or "",
+            "custom_metadata": list(custom_metadata or []),
             "chunk_id": chunk_id,
             "content": chunk.get("content", ""),
             "imageCaptions": chunk.get("imageCaptions", ""),
@@ -930,6 +976,7 @@ class BlobStorageDocumentIndexer:
         security_user_ids: Optional[List[str]] = None,
         security_group_ids: Optional[List[str]] = None,
         rbac_scope: str = "",
+        custom_metadata: Optional[List[Dict[str, str]]] = None,
     ):
         """Yield AI Search docs one-by-one (chunk -> doc), avoiding large in-memory lists."""
         for chunk in self._iter_chunks_for_data(data):
@@ -942,6 +989,7 @@ class BlobStorageDocumentIndexer:
                 security_user_ids=security_user_ids,
                 security_group_ids=security_group_ids,
                 rbac_scope=rbac_scope,
+                custom_metadata=custom_metadata,
             )
 
     async def _replace_parent_docs_stream(self, parent_id: str, docs_iter):
@@ -976,6 +1024,7 @@ class BlobStorageDocumentIndexer:
         security_user_ids: Optional[List[str]] = None,
         security_group_ids: Optional[List[str]] = None,
         rbac_scope: str = "",
+        custom_metadata: Optional[List[Dict[str, str]]] = None,
     ) -> int:
         """Stage docs in Blob then upload in batches, cleaning staging prefix afterwards.
 
@@ -1033,6 +1082,7 @@ class BlobStorageDocumentIndexer:
                 security_user_ids=security_user_ids,
                 security_group_ids=security_group_ids,
                 rbac_scope=rbac_scope,
+                custom_metadata=custom_metadata,
             ),
         )
         staged_count = 0

--- a/tests/test_blob_metadata.py
+++ b/tests/test_blob_metadata.py
@@ -1,0 +1,113 @@
+"""Tests for `_extract_custom_metadata` in `jobs.blob_storage_indexer`.
+
+The helper turns the raw blob metadata mapping (lowercased by Azure Storage)
+into the `custom_metadata` collection that gets stamped onto every AI Search
+document. These tests pin down its normalization rules so reserved security
+keys never leak into the user-facing field and so empty/whitespace values are
+dropped before they reach the index.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+
+def _load_extractor():
+    """Load `_extract_custom_metadata` without importing the full module.
+
+    `jobs.blob_storage_indexer` pulls in heavy Azure SDK and app dependencies
+    at import time. We only need the pure helper, so we execute the module
+    file with the first-party imports neutralised through lightweight stubs.
+    """
+    root = Path(__file__).resolve().parents[1]
+    module_path = root / "jobs" / "blob_storage_indexer.py"
+
+    stubs = {
+        "dependencies": {"get_config": lambda *a, **k: None},
+        "tools": {},
+        "tools.credentials": {"get_azure_client_id": lambda *a, **k: None},
+        "chunking": {"DocumentChunker": object},
+        "chunking.chunker_factory": {"ChunkerFactory": object},
+        "utils": {},
+        "utils.file_utils": {"_safe_delete": lambda *a, **k: None},
+    }
+    for name, attrs in stubs.items():
+        if name in sys.modules:
+            continue
+        module = types.ModuleType(name)
+        for attr, value in attrs.items():
+            setattr(module, attr, value)
+        sys.modules[name] = module
+
+    spec = importlib.util.spec_from_file_location(
+        "blob_storage_indexer_under_test", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module._extract_custom_metadata
+
+
+extract = _load_extractor()
+
+
+def test_extracts_plain_metadata_preserving_lowercase():
+    result = extract({"department": "finance", "owner": "alice"})
+
+    assert sorted(result, key=lambda item: item["key"]) == [
+        {"key": "department", "value": "finance"},
+        {"key": "owner", "value": "alice"},
+    ]
+
+
+def test_returns_empty_for_none_or_empty():
+    assert extract(None) == []
+    assert extract({}) == []
+
+
+def test_filters_all_reserved_security_keys():
+    meta = {
+        "metadata_security_user_ids": "u1",
+        "metadata_security_group_ids": "g1",
+        "metadata_security_id": "legacy",
+        "metadata_security_rbac_scope": "/subscriptions/x",
+        "department": "finance",
+    }
+
+    result = extract(meta)
+
+    assert result == [{"key": "department", "value": "finance"}]
+
+
+def test_drops_none_empty_and_whitespace_only_values():
+    meta = {
+        "department": "finance",
+        "missing": None,
+        "blank": "",
+        "spaces": "   ",
+    }
+
+    result = extract(meta)
+
+    assert result == [{"key": "department", "value": "finance"}]
+
+
+def test_preserves_numeric_strings_verbatim():
+    result = extract({"version": "42"})
+
+    assert result == [{"key": "version", "value": "42"}]
+
+
+def test_trims_and_lowercases_keys():
+    result = extract({"  Department  ": "Finance"})
+
+    assert result == [{"key": "department", "value": "Finance"}]
+
+
+def test_drops_entries_whose_key_is_empty_after_trim():
+    result = extract({"   ": "value"})
+
+    assert result == []


### PR DESCRIPTION
## Summary

Implements [Azure/GPT-RAG#487](https://github.com/Azure/GPT-RAG/issues/487) on the ingestion side: every user-defined tag set on a blob (for example, `az storage blob upload --metadata department=finance owner=alice`) is now extracted at indexing time and stamped onto each AI Search chunk as `custom_metadata`, a `Collection(Edm.ComplexType)` with `{key, value}` pairs.

## What changes

- `jobs/blob_storage_indexer.py`
  - New module-level helper `_extract_custom_metadata(meta)` and constant `_RESERVED_BLOB_METADATA_KEYS` (the four `metadata_security_*` keys). The helper trims+lowercases keys, drops empty/whitespace values, and never returns reserved security keys.
  - The existing `props.metadata` block now also captures `custom_metadata`; failures degrade to `[]` like the existing ACL handling.
  - `_to_search_doc`, `_iter_search_docs_for_blob`, and `_replace_parent_docs_via_staging` take a new `custom_metadata: Optional[List[Dict[str, str]]] = None` parameter so both the in-memory and the Excel staging paths emit the field.
- `tests/test_blob_metadata.py`: 7 focused unit tests covering plain extraction, `None`/empty input, reserved-key filtering, empty/whitespace value filtering, numeric string preservation, key normalization, and empty-after-trim keys.
- `CHANGELOG.md`: entry added under `[Unreleased]`.

## Architectural decision

A single, always-on `custom_metadata` field on the RAG index, populated unconditionally from blob metadata. No App Configuration key, no feature flag, no per-deployment toggle. Validated with Martin and approved by the maintainer. Reserved security keys are filtered so the user-facing field never collides with ACL plumbing.

## Required schema change

This change requires the matching `custom_metadata` field in the RAG index schema, shipped in `Azure/GPT-RAG` via `config/search/search.j2` (companion PR on the same issue). Operators must reapply the index schema and reingest existing documents to populate the field for back-catalogue blobs.

## Example query

```
$filter=custom_metadata/any(m: m/key eq 'department' and m/value eq 'finance')
```

The field is also `facetable`, so the same data can drive faceted navigation.

## Out of scope (intentional)

- Surfacing `custom_metadata` in the orchestrator prompt context. Will be a separate issue in `gpt-rag-orchestrator` if the issue author confirms it is needed.
- Promoting individual tags to typed top-level fields (date/int). Only on real demand.

## Validation

- `pytest tests/test_blob_metadata.py -v` -> 7 passed locally.
- `pytest` full suite is empty in this repo (per `AGENTS.md`); no regressions to existing tests.
- Azure validation (schema reapply + sample upload + filter query) is performed against the maintainer's Standard validation environment as part of the cross-repo rollout.

## Documentation

User-facing documentation will be updated by Steve in a separate PR on the `docs` branch (MkDocs site). Not touched here.

## Target branch

`develop`.
