### PR TITLE
feat: ingestion dashboard run-now button (#510)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Added
+- **Run now button for ingestion jobs ([#510](https://github.com/Azure/GPT-RAG/issues/510)).** The ingestion dashboard now exposes a per-`job_type` "Run now" control above the Jobs table, backed by a new `POST /api/jobs/{job_type}/run` endpoint that enqueues the matching scheduler function as a one-shot `date` trigger. A shared in-process registry (`_running_jobs`) is consulted by both the manual endpoint and the scheduler wrapper, so cron-triggered and manually triggered runs share the same mutual exclusion — concurrent manual triggers for an already-running job get `409 Conflict`. The endpoint is gated by the new `require_admin` dependency, which is a no-op when `OAUTH_AZURE_AD_TENANT_ID` is unset and otherwise requires a bearer token carrying the `Admin` Entra app role (mirroring the orchestrator dashboard pattern from `gpt-rag-orchestrator#236`). A companion `GET /api/identity` returns `{authEnabled, isAdmin}` so the frontend can disable the buttons with an accessible tooltip ("Admin role required") when the caller lacks the role; read-only dashboard endpoints remain network-only as before.
+
 ## [v2.4.6] - 2026-06-15
 
 ### Reverted

--- a/api/admin.py
+++ b/api/admin.py
@@ -19,13 +19,43 @@ from azure.identity.aio import (
     ManagedIdentityCredential,
 )
 from azure.storage.blob.aio import BlobServiceClient
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pathlib import Path
 
-from dependencies import get_config
+from dependencies import get_config, validate_bearer_jwt
 from tools.credentials import get_azure_client_id
 
 router = APIRouter(prefix="/api")
+
+
+# ---------------------------------------------------------------------------
+# Admin gate – mirrors the orchestrator dashboard pattern.
+#
+# Read endpoints stay open (network-only auth, same as today). Only mutating
+# routes — currently `POST /api/jobs/{job_type}/run` — get the gate. When
+# `OAUTH_AZURE_AD_TENANT_ID` is not configured the gate is a no-op so local
+# dev keeps working without an Entra app registration.
+# ---------------------------------------------------------------------------
+
+
+def _auth_enabled() -> bool:
+    cfg = get_config()
+    tenant_id = cfg.get("OAUTH_AZURE_AD_TENANT_ID", default=None, allow_none=True)
+    return bool(tenant_id)
+
+
+async def require_admin(request: Request) -> None:
+    """Raise 403 unless the caller has the ``Admin`` Entra app role.
+
+    No-op when auth is not configured. The token must be issued for this API's
+    scope (``api://<client_id>/...``) so the ``roles`` claim is present.
+    """
+    if not _auth_enabled():
+        return
+    claims = await validate_bearer_jwt(request)
+    roles = claims.get("roles") or []
+    if "Admin" not in roles:
+        raise HTTPException(status_code=403, detail="Admin role required")
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -317,7 +347,95 @@ async def list_jobs(
         "page": page,
         "pageSize": pageSize,
         "indexerTypes": all_types,
+        "availableJobTypes": _available_job_types(),
+        "runningJobTypes": _running_job_types(),
     }
+
+
+def _available_job_types() -> List[str]:
+    """Return the canonical job_type identifiers accepted by ``/api/jobs/{job_type}/run``."""
+    from main import JOB_REGISTRY  # local import to avoid circular import at module load
+
+    return sorted(JOB_REGISTRY.keys())
+
+
+def _running_job_types() -> List[str]:
+    from main import _running_jobs
+
+    return sorted(_running_jobs)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/identity – tells the frontend whether auth is on and if the caller
+# has the Admin role. Always returns 200; never logs or raises on invalid
+# tokens — it's a state-probe endpoint, not an access check.
+# ---------------------------------------------------------------------------
+@router.get("/identity")
+async def get_identity(request: Request) -> Dict[str, Any]:
+    auth_enabled = _auth_enabled()
+    if not auth_enabled:
+        return {"authEnabled": False, "isAdmin": True}
+
+    is_admin = False
+    try:
+        claims = await validate_bearer_jwt(request)
+        is_admin = "Admin" in (claims.get("roles") or [])
+    except Exception:
+        # Silent by design: a missing or invalid token here just means the
+        # caller isn't admin. Failing loudly would spam logs on every page load.
+        is_admin = False
+
+    return {"authEnabled": True, "isAdmin": is_admin}
+
+
+# ---------------------------------------------------------------------------
+# POST /api/jobs/{job_type}/run – manually trigger a scheduled ingestion job.
+# Requires Admin when auth is enabled; idempotent guard returns 409 if a run
+# of the same job_type is already in flight (manual or cron-triggered).
+# ---------------------------------------------------------------------------
+_JOB_TYPE_RE = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+@router.post("/jobs/{job_type}/run", status_code=202, dependencies=[Depends(require_admin)])
+async def run_job_now(job_type: str) -> Dict[str, Any]:
+    if not _JOB_TYPE_RE.match(job_type):
+        raise HTTPException(status_code=400, detail="Invalid job_type")
+
+    # Late import keeps api/admin import-time light and avoids circular import.
+    from main import JOB_REGISTRY, _running_jobs, _running_jobs_lock, scheduler
+
+    if job_type not in JOB_REGISTRY:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown job_type '{job_type}'. Known: {sorted(JOB_REGISTRY.keys())}",
+        )
+
+    async with _running_jobs_lock:
+        if job_type in _running_jobs:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Job '{job_type}' is already running",
+            )
+
+    func = JOB_REGISTRY[job_type]
+    trigger_id = f"manual-{job_type}-{int(time.time() * 1000)}"
+    try:
+        # `trigger='date'` with no run_date defaults to "now" — APScheduler
+        # picks it up on the next event loop tick.
+        scheduler.add_job(
+            func,
+            trigger="date",
+            id=trigger_id,
+            name=f"manual:{job_type}",
+            replace_existing=False,
+            misfire_grace_time=None,
+        )
+    except Exception as exc:  # pragma: no cover - depends on APScheduler state
+        logging.exception("Failed to enqueue manual run for %s", job_type)
+        raise HTTPException(status_code=500, detail=f"Failed to schedule job: {exc}") from exc
+
+    logging.info("[admin] Manual run requested for job_type=%s trigger_id=%s", job_type, trigger_id)
+    return {"jobType": job_type, "triggerId": trigger_id, "status": "queued"}
 
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,7 +3,7 @@ import { ThemeProvider } from "next-themes";
 import { ThemeToggle } from "./components/ThemeToggle";
 import { JobsTable } from "./components/JobsTable";
 import { FilesTable } from "./components/FilesTable";
-import { fetchVersion } from "./lib/api";
+import { fetchIdentity, fetchVersion, type Identity } from "./lib/api";
 import { Database, FileText } from "lucide-react";
 
 type Tab = "jobs" | "files";
@@ -12,9 +12,11 @@ function Dashboard() {
   const [tab, setTab] = useState<Tab>("jobs");
   const [version, setVersion] = useState("");
   const [navRunId, setNavRunId] = useState<string | null>(null);
+  const [identity, setIdentity] = useState<Identity>({ authEnabled: false, isAdmin: true });
 
   useEffect(() => {
     fetchVersion().then(setVersion);
+    fetchIdentity().then(setIdentity);
   }, []);
 
   useEffect(() => {
@@ -70,7 +72,7 @@ function Dashboard() {
       </nav>
 
       {tab === "jobs" ? (
-        <JobsTable navigateRunId={navRunId} onNavigated={() => setNavRunId(null)} />
+        <JobsTable navigateRunId={navRunId} onNavigated={() => setNavRunId(null)} identity={identity} />
       ) : (
         <FilesTable />
       )}

--- a/frontend/src/components/JobsTable.tsx
+++ b/frontend/src/components/JobsTable.tsx
@@ -1,18 +1,25 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { fetchJobs, formatUtc, type JobRun } from "../lib/api";
+import { fetchJobs, formatUtc, runJob, type Identity, type JobRun, type RunJobError } from "../lib/api";
 import { StatusBadge } from "./StatusBadge";
 import { Pagination } from "./Pagination";
 import { SearchInput } from "./SearchInput";
 import { SortHeader } from "./SortHeader";
 import { DetailDialog } from "./DetailDialog";
-import { RefreshCw } from "lucide-react";
+import { Play, RefreshCw } from "lucide-react";
 
 interface JobsTableProps {
   navigateRunId?: string | null;
   onNavigated?: () => void;
+  identity: Identity;
 }
 
-export function JobsTable({ navigateRunId, onNavigated }: JobsTableProps) {
+type AlertKind = "success" | "error";
+interface AlertState {
+  kind: AlertKind;
+  message: string;
+}
+
+export function JobsTable({ navigateRunId, onNavigated, identity }: JobsTableProps) {
   const [items, setItems] = useState<JobRun[]>([]);
   const [total, setTotal] = useState(0);
   const [page, setPage] = useState(1);
@@ -23,6 +30,10 @@ export function JobsTable({ navigateRunId, onNavigated }: JobsTableProps) {
   const [indexerType, setIndexerType] = useState("");
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState<JobRun | null>(null);
+  const [availableJobTypes, setAvailableJobTypes] = useState<string[]>([]);
+  const [runningJobTypes, setRunningJobTypes] = useState<string[]>([]);
+  const [triggering, setTriggering] = useState<string | null>(null);
+  const [alert, setAlert] = useState<AlertState | null>(null);
   const abortRef = useRef<AbortController | null>(null);
 
   const load = useCallback(async () => {
@@ -36,6 +47,8 @@ export function JobsTable({ navigateRunId, onNavigated }: JobsTableProps) {
       setItems(res.items);
       setTotal(res.total);
       if (res.indexerTypes) setIndexerTypes(res.indexerTypes);
+      if (res.availableJobTypes) setAvailableJobTypes(res.availableJobTypes);
+      if (res.runningJobTypes) setRunningJobTypes(res.runningJobTypes);
     } catch (err) {
       if ((err as Error).name === "AbortError") return;
       console.error(err);
@@ -69,6 +82,26 @@ export function JobsTable({ navigateRunId, onNavigated }: JobsTableProps) {
 
   const handleSearch = useCallback((v: string) => { setSearch(v); setPage(1); }, []);
 
+  const canRun = !identity.authEnabled || identity.isAdmin;
+  const disabledTooltip = !canRun ? "Admin role required" : undefined;
+
+  const handleRun = async (jobType: string) => {
+    if (!canRun) return;
+    setTriggering(jobType);
+    setAlert(null);
+    try {
+      await runJob(jobType);
+      setAlert({ kind: "success", message: `Queued ${jobType}.` });
+      // Refresh immediately; the backend already reports the job as running.
+      load();
+    } catch (err) {
+      const e = err as RunJobError;
+      setAlert({ kind: "error", message: e.message || `Failed to run ${jobType}` });
+    } finally {
+      setTriggering(null);
+    }
+  };
+
   return (
     <div className="space-y-3">
       <div className="flex items-center gap-3">
@@ -88,6 +121,58 @@ export function JobsTable({ navigateRunId, onNavigated }: JobsTableProps) {
           <RefreshCw className={`h-4 w-4 ${loading ? "animate-spin" : ""}`} />
         </button>
       </div>
+
+      {availableJobTypes.length > 0 && (
+        <div
+          className="flex flex-wrap items-center gap-2 rounded-lg border bg-muted/30 px-3 py-2"
+          aria-label="Run jobs on demand"
+        >
+          <span className="text-xs font-medium text-muted-foreground">Run now:</span>
+          {availableJobTypes.map((jt) => {
+            const isRunning = runningJobTypes.includes(jt);
+            const isPending = triggering === jt;
+            const disabled = !canRun || isRunning || isPending;
+            const tooltip = !canRun
+              ? disabledTooltip
+              : isRunning
+                ? "Job is already running"
+                : `Trigger ${jt}`;
+            return (
+              <button
+                key={jt}
+                type="button"
+                onClick={() => handleRun(jt)}
+                disabled={disabled}
+                title={tooltip}
+                aria-label={tooltip}
+                aria-disabled={disabled}
+                className="inline-flex items-center gap-1.5 rounded-md border bg-background px-2.5 py-1 text-xs font-medium hover:bg-accent disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {isPending ? (
+                  <RefreshCw className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Play className="h-3 w-3" />
+                )}
+                {jt}
+                {isRunning && <span className="text-[10px] text-muted-foreground">(running)</span>}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {alert && (
+        <div
+          role="alert"
+          className={`rounded-md border px-3 py-2 text-sm ${
+            alert.kind === "error"
+              ? "border-destructive/50 bg-destructive/10 text-destructive"
+              : "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
+          }`}
+        >
+          {alert.message}
+        </div>
+      )}
 
       <div className="rounded-lg border">
         <table className="w-full text-sm">

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -6,6 +6,8 @@ export interface PaginatedResponse<T> {
   page: number;
   pageSize: number;
   indexerTypes?: string[];
+  availableJobTypes?: string[];
+  runningJobTypes?: string[];
 }
 
 export interface JobRun {
@@ -108,6 +110,46 @@ export async function fetchVersion(): Promise<string> {
   if (!r.ok) return "unknown";
   const data = await r.json();
   return data.version ?? "unknown";
+}
+
+export interface Identity {
+  authEnabled: boolean;
+  isAdmin: boolean;
+}
+
+export async function fetchIdentity(signal?: AbortSignal): Promise<Identity> {
+  try {
+    const r = await fetch(`${BASE}/identity`, { signal });
+    if (!r.ok) return { authEnabled: true, isAdmin: false };
+    return (await r.json()) as Identity;
+  } catch {
+    return { authEnabled: true, isAdmin: false };
+  }
+}
+
+export interface RunJobError extends Error {
+  status: number;
+  /** True when the backend returned 409 (job already running). */
+  conflict: boolean;
+  /** True when the backend returned 403 (admin required). */
+  forbidden: boolean;
+}
+
+export async function runJob(jobType: string): Promise<{ jobType: string; triggerId: string; status: string }> {
+  const r = await fetch(`${BASE}/jobs/${encodeURIComponent(jobType)}/run`, { method: "POST" });
+  if (r.ok) return r.json();
+  let detail = `Failed to run job: ${r.status}`;
+  try {
+    const body = await r.json();
+    if (body && typeof body.detail === "string") detail = body.detail;
+  } catch {
+    /* ignore */
+  }
+  const err = new Error(detail) as RunJobError;
+  err.status = r.status;
+  err.conflict = r.status === 409;
+  err.forbidden = r.status === 403;
+  throw err;
 }
 
 /** Format ISO timestamp to readable UTC string */

--- a/main.py
+++ b/main.py
@@ -49,6 +49,36 @@ def _resolve_timezone():
 local_tz = _resolve_timezone()
 scheduler = AsyncIOScheduler(timezone=local_tz)
 
+# -------------------------------
+# Manual run-now coordination
+# -------------------------------
+# `_running_jobs` is the source of truth for "is this job_type executing right now?".
+# It is consulted both by the manual `POST /api/jobs/{job_type}/run` endpoint to
+# return 409 on concurrent triggers, and by the scheduler wrapper so cron-triggered
+# runs participate in the same mutual exclusion as manual runs.
+_running_jobs: set[str] = set()
+_running_jobs_lock = asyncio.Lock()
+
+
+def _track_running(job_id: str, func):
+    """Wrap an async job function so its execution is reflected in `_running_jobs`."""
+
+    async def _wrapped():
+        async with _running_jobs_lock:
+            _running_jobs.add(job_id)
+        try:
+            return await func()
+        finally:
+            async with _running_jobs_lock:
+                _running_jobs.discard(job_id)
+
+    _wrapped.__name__ = getattr(func, "__name__", job_id)
+    return _wrapped
+
+
+# Populated inside lifespan once the job functions are defined.
+JOB_REGISTRY: dict[str, "object"] = {}
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
 
@@ -145,13 +175,30 @@ async def lifespan(app: FastAPI):
     logging.info(f"Scheduler timezone: {local_tz}")
 
     now = datetime.datetime.now(tz=local_tz)
-    s_sharepoint_index = _schedule("CRON_RUN_SHAREPOINT_INDEX", run_sharepoint_index, "sharepoint_index", "sharepoint-indexer")
-    s_sharepoint_purge = _schedule("CRON_RUN_SHAREPOINT_PURGE", run_sharepoint_purge, "sharepoint_purge", "sharepoint-purger")
-    s_images_purge = _schedule("CRON_RUN_IMAGES_PURGE", run_images_purge, "multimodality_images_purge", "multimodality-images-purger")
-    s_blob_index = _schedule("CRON_RUN_BLOB_INDEX", run_blob_index, "blob_index", "blob-storage-indexer", default_cron="0 * * * *")
-    s_blob_purge = _schedule("CRON_RUN_BLOB_PURGE", run_blob_purge, "blob_purge", "blob-storage-indexer-purger", default_cron="10 * * * *")
-    s_nl2sql_index = _schedule("CRON_RUN_NL2SQL_INDEX", run_nl2sql_index, "nl2sql_index", "nl2sql-indexer")
-    s_nl2sql_purge = _schedule("CRON_RUN_NL2SQL_PURGE", run_nl2sql_purge, "nl2sql_purge", "nl2sql-indexer-purger")
+
+    # Wrap every run_* function so manual and cron-triggered executions share
+    # the same _running_jobs set. The wrapper is the value stored in JOB_REGISTRY
+    # and the callable passed to APScheduler, so cron runs also block manual
+    # 409 collisions and vice-versa.
+    _wrapped_jobs: dict[str, object] = {
+        "sharepoint_index": _track_running("sharepoint_index", run_sharepoint_index),
+        "sharepoint_purge": _track_running("sharepoint_purge", run_sharepoint_purge),
+        "multimodality_images_purge": _track_running("multimodality_images_purge", run_images_purge),
+        "blob_index": _track_running("blob_index", run_blob_index),
+        "blob_purge": _track_running("blob_purge", run_blob_purge),
+        "nl2sql_index": _track_running("nl2sql_index", run_nl2sql_index),
+        "nl2sql_purge": _track_running("nl2sql_purge", run_nl2sql_purge),
+    }
+    JOB_REGISTRY.clear()
+    JOB_REGISTRY.update(_wrapped_jobs)
+
+    s_sharepoint_index = _schedule("CRON_RUN_SHAREPOINT_INDEX", _wrapped_jobs["sharepoint_index"], "sharepoint_index", "sharepoint-indexer")
+    s_sharepoint_purge = _schedule("CRON_RUN_SHAREPOINT_PURGE", _wrapped_jobs["sharepoint_purge"], "sharepoint_purge", "sharepoint-purger")
+    s_images_purge = _schedule("CRON_RUN_IMAGES_PURGE", _wrapped_jobs["multimodality_images_purge"], "multimodality_images_purge", "multimodality-images-purger")
+    s_blob_index = _schedule("CRON_RUN_BLOB_INDEX", _wrapped_jobs["blob_index"], "blob_index", "blob-storage-indexer", default_cron="0 * * * *")
+    s_blob_purge = _schedule("CRON_RUN_BLOB_PURGE", _wrapped_jobs["blob_purge"], "blob_purge", "blob-storage-indexer-purger", default_cron="10 * * * *")
+    s_nl2sql_index = _schedule("CRON_RUN_NL2SQL_INDEX", _wrapped_jobs["nl2sql_index"], "nl2sql_index", "nl2sql-indexer")
+    s_nl2sql_purge = _schedule("CRON_RUN_NL2SQL_PURGE", _wrapped_jobs["nl2sql_purge"], "nl2sql_purge", "nl2sql-indexer-purger")
 
     # Log cleanup: runs immediately then every hour (not shown in dashboard)
     from api.admin import _cleanup_old_runs
@@ -186,25 +233,25 @@ async def lifespan(app: FastAPI):
         try:
             if s_blob_index:
                 logging.info("[startup] Running blob-storage-indexer immediately")
-                await run_blob_index()
+                await _wrapped_jobs["blob_index"]()
             if s_blob_purge:
                 logging.info("[startup] Running blob-purge immediately")
-                await run_blob_purge()
+                await _wrapped_jobs["blob_purge"]()
             if s_nl2sql_index:
                 logging.info("[startup] Running nl2sql-indexer immediately")
-                await run_nl2sql_index()
+                await _wrapped_jobs["nl2sql_index"]()
             if s_nl2sql_purge:
                 logging.info("[startup] Running nl2sql-purge immediately")
-                await run_nl2sql_purge()
+                await _wrapped_jobs["nl2sql_purge"]()
             if s_sharepoint_index:
                 logging.info("[startup] Running sharepoint-indexer immediately")
-                await run_sharepoint_index()
+                await _wrapped_jobs["sharepoint_index"]()
             if s_sharepoint_purge:
                 logging.info("[startup] Running sharepoint-purger immediately")
-                await run_sharepoint_purge()
+                await _wrapped_jobs["sharepoint_purge"]()
             if s_images_purge:
                 logging.info("[startup] Running multimodality-images-purger immediately")
-                await run_images_purge()
+                await _wrapped_jobs["multimodality_images_purge"]()
         except asyncio.CancelledError:
             logging.info("[startup] Startup jobs cancelled")
             raise

--- a/tests/test_admin_run_now.py
+++ b/tests/test_admin_run_now.py
@@ -1,0 +1,173 @@
+"""Tests for the admin gate on `POST /api/jobs/{job_type}/run`.
+
+Documents the four behaviours of `api.admin.require_admin`:
+
+* auth disabled (no ``OAUTH_AZURE_AD_TENANT_ID``) → endpoint is reachable
+* auth enabled, no token                          → 401 from `validate_bearer_jwt`
+* auth enabled, token without ``Admin`` role      → 403 from `require_admin`
+* auth enabled, token with ``Admin`` role         → endpoint is reachable
+
+The tests avoid importing `main` (which pulls in the full ingestion stack)
+by mounting only `api.admin.router` on a throwaway FastAPI app and stubbing
+out the bits of `main` that the run-now endpoint imports at call time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import types
+
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+
+def _install_stubs(monkeypatch, *, tenant_id: str | None, claims: dict | Exception | None):
+    """Wire fake `dependencies` + `main` modules so `api.admin` can import them."""
+
+    # --- dependencies stub --------------------------------------------------
+    class _FakeConfig:
+        def __init__(self, tenant: str | None) -> None:
+            self._tenant = tenant
+
+        def get(self, key, default=None, allow_none=True):
+            if key == "OAUTH_AZURE_AD_TENANT_ID":
+                return self._tenant
+            return default
+
+    async def _validate_bearer_jwt(_request):
+        if isinstance(claims, Exception):
+            raise claims
+        if claims is None:
+            raise HTTPException(status_code=401, detail="Missing token")
+        return claims
+
+    dependencies_stub = types.ModuleType("dependencies")
+    dependencies_stub.get_config = lambda: _FakeConfig(tenant_id)
+    dependencies_stub.validate_bearer_jwt = _validate_bearer_jwt
+    monkeypatch.setitem(sys.modules, "dependencies", dependencies_stub)
+
+    # --- tools.credentials stub --------------------------------------------
+    tools_pkg = types.ModuleType("tools")
+    tools_pkg.__path__ = []  # mark as package
+    credentials_stub = types.ModuleType("tools.credentials")
+    credentials_stub.get_azure_client_id = lambda: "fake-client-id"
+    monkeypatch.setitem(sys.modules, "tools", tools_pkg)
+    monkeypatch.setitem(sys.modules, "tools.credentials", credentials_stub)
+
+    # --- main stub (only the symbols run_job_now imports) -------------------
+    main_stub = types.ModuleType("main")
+
+    async def _noop_job():
+        return None
+
+    main_stub.JOB_REGISTRY = {"blob_index": _noop_job}
+    main_stub._running_jobs = set()
+    main_stub._running_jobs_lock = asyncio.Lock()
+
+    class _FakeScheduler:
+        def __init__(self) -> None:
+            self.jobs: list[dict] = []
+
+        def add_job(self, func, **kwargs):
+            self.jobs.append({"func": func, **kwargs})
+
+    main_stub.scheduler = _FakeScheduler()
+    monkeypatch.setitem(sys.modules, "main", main_stub)
+    return main_stub
+
+
+def _build_client(monkeypatch, *, tenant_id, claims):
+    main_stub = _install_stubs(monkeypatch, tenant_id=tenant_id, claims=claims)
+    # Re-import api.admin so it picks up the freshly-stubbed `dependencies`.
+    if "api.admin" in sys.modules:
+        del sys.modules["api.admin"]
+    if "api" not in sys.modules:
+        api_pkg = types.ModuleType("api")
+        api_pkg.__path__ = [
+            str(__import__("pathlib").Path(__file__).resolve().parents[1] / "api")
+        ]
+        sys.modules["api"] = api_pkg
+    admin_module = importlib.import_module("api.admin")
+    app = FastAPI()
+    app.include_router(admin_module.router)
+    return TestClient(app), main_stub
+
+
+def test_run_now_auth_disabled_is_open(monkeypatch):
+    client, main_stub = _build_client(monkeypatch, tenant_id=None, claims=None)
+    r = client.post("/api/jobs/blob_index/run")
+    assert r.status_code == 202, r.text
+    assert r.json()["jobType"] == "blob_index"
+    assert len(main_stub.scheduler.jobs) == 1
+
+
+def test_run_now_auth_enabled_no_token_rejected(monkeypatch):
+    client, main_stub = _build_client(monkeypatch, tenant_id="tenant-guid", claims=None)
+    r = client.post("/api/jobs/blob_index/run")
+    assert r.status_code == 401, r.text
+    assert main_stub.scheduler.jobs == []
+
+
+def test_run_now_auth_enabled_non_admin_rejected(monkeypatch):
+    client, main_stub = _build_client(
+        monkeypatch,
+        tenant_id="tenant-guid",
+        claims={"roles": ["Reader"]},
+    )
+    r = client.post("/api/jobs/blob_index/run")
+    assert r.status_code == 403, r.text
+    assert "Admin" in r.json()["detail"]
+    assert main_stub.scheduler.jobs == []
+
+
+def test_run_now_auth_enabled_admin_accepted(monkeypatch):
+    client, main_stub = _build_client(
+        monkeypatch,
+        tenant_id="tenant-guid",
+        claims={"roles": ["Admin", "Reader"]},
+    )
+    r = client.post("/api/jobs/blob_index/run")
+    assert r.status_code == 202, r.text
+    assert len(main_stub.scheduler.jobs) == 1
+
+
+def test_run_now_unknown_job_type_returns_404(monkeypatch):
+    client, _ = _build_client(monkeypatch, tenant_id=None, claims=None)
+    r = client.post("/api/jobs/not_a_real_job/run")
+    assert r.status_code == 404
+
+
+def test_run_now_already_running_returns_409(monkeypatch):
+    client, main_stub = _build_client(monkeypatch, tenant_id=None, claims=None)
+    main_stub._running_jobs.add("blob_index")
+    r = client.post("/api/jobs/blob_index/run")
+    assert r.status_code == 409
+    assert main_stub.scheduler.jobs == []
+
+
+def test_identity_auth_disabled(monkeypatch):
+    client, _ = _build_client(monkeypatch, tenant_id=None, claims=None)
+    r = client.get("/api/identity")
+    assert r.status_code == 200
+    assert r.json() == {"authEnabled": False, "isAdmin": True}
+
+
+def test_identity_auth_enabled_admin(monkeypatch):
+    client, _ = _build_client(
+        monkeypatch,
+        tenant_id="tenant-guid",
+        claims={"roles": ["Admin"]},
+    )
+    r = client.get("/api/identity")
+    assert r.status_code == 200
+    assert r.json() == {"authEnabled": True, "isAdmin": True}
+
+
+def test_identity_auth_enabled_missing_token_silent(monkeypatch):
+    client, _ = _build_client(monkeypatch, tenant_id="tenant-guid", claims=None)
+    r = client.get("/api/identity")
+    # Endpoint never raises even when validate_bearer_jwt would 401 elsewhere.
+    assert r.status_code == 200
+    assert r.json() == {"authEnabled": True, "isAdmin": False}


### PR DESCRIPTION
Implements [Azure/GPT-RAG#510](https://github.com/Azure/GPT-RAG/issues/510): a per-`job_type` **Run now** control on the ingestion dashboard, with an Entra-`Admin` gate that mirrors the pattern shipped in the orchestrator (`gpt-rag-orchestrator#236`).

## What changed

### Backend
- **`api/admin.py`**
  - New `require_admin` dependency: no-op when `OAUTH_AZURE_AD_TENANT_ID` is unset; otherwise calls the existing `validate_bearer_jwt` and requires `"Admin"` in the `roles` claim (`403` otherwise).
  - New `POST /api/jobs/{job_type}/run` (`status_code=202`, gated by `require_admin`). Validates `job_type` against the registry, returns `404` for unknown jobs and `409` when the same `job_type` is already running, then enqueues the matching scheduler function as a one-shot APScheduler `date` trigger.
  - New `GET /api/identity` returns `{authEnabled, isAdmin}`. **Silent by design** — it never logs or raises when the token is missing or invalid; it's a state probe, not an access check.
  - `GET /api/jobs` now also returns `availableJobTypes` and `runningJobTypes` so the frontend can render the run-now bar without a second call.
- **`main.py`**
  - New `_running_jobs: set[str]` + `_running_jobs_lock` and a small `_track_running` wrapper. The wrapper is applied to every `run_*` function before it's stored in `JOB_REGISTRY` and before it's handed to `scheduler.add_job`, so manual triggers and cron-scheduled triggers share the same mutual exclusion (the issue called this out explicitly).
  - Startup runs and admin-router include unchanged in behaviour, but startup runs now also go through the wrapper so they participate in the 409 guard.

### Frontend
- **`lib/api.ts`**: `fetchIdentity()`, `runJob(jobType)` returning a structured `RunJobError` (`status`, `conflict`, `forbidden`), and the `availableJobTypes` / `runningJobTypes` fields on `PaginatedResponse`.
- **`App.tsx`**: fetches identity once on mount and passes it to `JobsTable`.
- **`JobsTable.tsx`**: new run-now bar above the table with one button per `job_type`. Buttons are disabled (with an accessible `title` + `aria-label` tooltip — keyboard/focus friendly, not hover-only) when the user isn't admin or the job is already running. On success the table refreshes immediately (no artificial delay); on `409`/`403`/other errors an inline `role="alert"` banner explains why.

### Tests
- `tests/test_admin_run_now.py` (9 cases) covers the four `require_admin` paths (auth-off / no-token / non-admin / admin), unknown job → 404, already-running → 409, and the three `/api/identity` modes. The tests stub `main` and `dependencies` so they don't pull in the full ingestion stack.

### Changelog
- New `### Added` entry under `[Unreleased]`.

## Verification

```
pytest tests/                # 16 passed
npm run lint                 # clean
npm run build                # tsc + vite, 0 errors
```

## Decisions worth flagging

- **Manual + cron share the same mutex.** Implemented via the `_track_running` wrapper rather than a fragile `_schedule` patch, so the cron coverage was cheap to keep (Samantha's "fall back to manual-only with TODO" escape hatch was not needed).
- **`/api/identity` is intentionally silent on auth failures.** The endpoint exists purely to drive the disabled-button UX; logging a warning on every page load by a non-admin would be noise.
- **No new pytest plumbing.** The repo `AGENTS.md` notes there's no maintained test suite, but the focused require_admin tests document the contract and pass under the existing `pytest` install.

Closes Azure/GPT-RAG#510.