### PR TITLE
fix: return flat settings and authEnabled from GET /api/config (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Configuration tab in the operator dashboard was blank ([#242](https://github.com/Azure/gpt-rag-ingestion/issues/242)):** `GET /api/config` returned `{sections, canEdit}` but the typed `ConfigResponse` and the `ConfigurationTab` frontend also read a top-level `settings` array and an `authEnabled` flag. With `res.settings` undefined the tab crashed with `TypeError: undefined is not iterable` and rendered nothing. The endpoint now returns both the grouped `sections` and a flat `settings` list (built from the same `_read_setting(cfg, spec)` calls so the two views stay in lock-step) plus `authEnabled` derived from `_auth_enabled()`. The existing `sections` shape is unchanged, so no other callers are affected.
+
 ## [v2.4.7] - 2026-06-18
 
 ### User and operator impact

--- a/api/admin.py
+++ b/api/admin.py
@@ -816,12 +816,20 @@ async def get_config_settings(request: Request) -> Dict[str, Any]:
     or invalid token simply yields `canEdit: false` without raising.
     """
     cfg = get_config()
+    # Build each setting exactly once, then surface it under both the grouped
+    # `sections` view (used by the section-aware UI) and a flat `settings`
+    # list (the contract the typed frontend `ConfigResponse` reads). This
+    # keeps the two views in lock-step and matches the documented API shape.
     by_section: Dict[str, List[Dict[str, Any]]] = {s["id"]: [] for s in CONFIG_SECTIONS}
+    flat_settings: List[Dict[str, Any]] = []
     for spec in SETTINGS:
-        by_section.setdefault(spec.section, []).append(_read_setting(cfg, spec))
+        setting = _read_setting(cfg, spec)
+        by_section.setdefault(spec.section, []).append(setting)
+        flat_settings.append(setting)
 
+    auth_enabled = _auth_enabled()
     can_edit = True
-    if _auth_enabled():
+    if auth_enabled:
         can_edit = False
         try:
             claims = await validate_bearer_jwt(request)
@@ -834,7 +842,9 @@ async def get_config_settings(request: Request) -> Dict[str, Any]:
             {"id": s["id"], "label": s["label"], "settings": by_section.get(s["id"], [])}
             for s in CONFIG_SECTIONS
         ],
+        "settings": flat_settings,
         "canEdit": can_edit,
+        "authEnabled": auth_enabled,
     }
 
 

--- a/tests/test_admin_config.py
+++ b/tests/test_admin_config.py
@@ -231,6 +231,54 @@ def test_get_config_open_when_auth_enabled_but_no_token(monkeypatch):
     assert r.json()["canEdit"] is False  # auth on + no admin token = read-only
 
 
+def test_get_config_returns_flat_settings_and_auth_enabled(monkeypatch):
+    """Issue #242: the typed `ConfigResponse` contract requires a top-level
+    flat `settings` array and `authEnabled` flag in addition to `sections`.
+    The frontend reads `res.settings` directly; without it the Configuration
+    tab crashes with `TypeError: undefined is not iterable`.
+    """
+    # Auth-off case: `authEnabled` must be False, `settings` must be the
+    # flattened section settings (same objects, same order).
+    client, _, admin_module = _build_client(
+        monkeypatch,
+        tenant_id=None,
+        claims=None,
+        config_values={
+            "CRON_RUN_BLOB_INDEX": "0 * * * *",
+            "CHUNKING_NUM_TOKENS": "512",
+            "MULTIMODAL": "true",
+        },
+    )
+    r = client.get("/api/config")
+    assert r.status_code == 200, r.text
+    body = r.json()
+
+    assert "settings" in body, "top-level `settings` array missing (issue #242)"
+    assert "authEnabled" in body, "top-level `authEnabled` flag missing (issue #242)"
+    assert body["authEnabled"] is False
+
+    flat = body["settings"]
+    assert isinstance(flat, list) and flat, "`settings` must be a non-empty list"
+
+    # Flat list must equal the flattened section settings, preserving the
+    # declared `SETTINGS` order so the two views can never disagree.
+    expected = [
+        setting
+        for section in body["sections"]
+        for setting in section["settings"]
+    ]
+    assert flat == expected
+    assert sorted(s["key"] for s in flat) == sorted(admin_module.ALLOWED_KEYS)
+
+    # Auth-on case: `authEnabled` must reflect `_auth_enabled()`.
+    client_authed, _, _ = _build_client(
+        monkeypatch, tenant_id="tenant-guid", claims=None
+    )
+    body_authed = client_authed.get("/api/config").json()
+    assert body_authed["authEnabled"] is True
+    assert "settings" in body_authed and body_authed["settings"]
+
+
 # ---------------------------------------------------------------------------
 # PUT /api/config — auth gate
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

Bug fix for the operator dashboard Configuration tab regression in v2.4.7.

Fixes [#242](https://github.com/Azure/gpt-rag-ingestion/issues/242).

## Root cause

`GET /api/config` returned `{sections, canEdit}` but the typed `ConfigResponse` in `frontend/src/lib/api.ts` and the `ConfigurationTab.tsx` component also read a top-level `settings` array (line 32: `for (const s of settings)`) and an `authEnabled` flag (line 57: `config?.authEnabled`). With `res.settings` undefined the tab crashed with `TypeError: undefined is not iterable` and rendered blank.

## Fix

Option A from the issue: extend `get_config_settings` in `api/admin.py` to also return a flat `settings` list and `authEnabled`. Each setting is built exactly once via `_read_setting(cfg, spec)` and surfaced under both the grouped `sections` view and the flat `settings` list so the two views cannot disagree. `sections` shape is unchanged; no other callers are affected. No frontend changes were needed because `ConfigResponse` already declared both fields.

## Validation

- `pytest` full suite: 26 passed (was 25; +1 focused test in `tests/test_admin_config.py` asserting the flat `settings` array equals the flattened section settings and `authEnabled` reflects `_auth_enabled()` both on and off).

## Target

Feature work, targets `develop` per repo convention.