### PR TITLE
Remove Docker Hub dependency from ingestion build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Remote ACR build resilience and Docker Hub independence:** The frontend build stage now uses the Microsoft Container Registry Node 20 devcontainer image instead of Docker Hub's `node:20-slim`, and both deployment scripts retry transient `az acr build` failures with visible attempt counts, retry delays, and a final actionable error message.
+
 ## [v2.4.13] - 2026-06-19
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ---- Stage 1: Build the frontend ----
-FROM node:20-slim AS frontend-build
+FROM mcr.microsoft.com/devcontainers/javascript-node:20-bookworm AS frontend-build
 WORKDIR /build
 COPY frontend/package*.json ./frontend/
 RUN cd frontend && npm ci

--- a/scripts/deploy.ps1
+++ b/scripts/deploy.ps1
@@ -14,6 +14,8 @@ $label = 'gpt-rag'
 $imageRepository = 'data-ingestion'
 $appConfigKey = 'DATA_INGEST_APP_NAME'
 $identitySuffix = 'dataingest'
+$acrBuildMaxAttempts = 3
+$acrBuildRetryDelaySeconds = 30
 
 function Write-Green($msg) { Write-Host $msg -ForegroundColor Green }
 function Write-Blue($msg) { Write-Host $msg -ForegroundColor Cyan }
@@ -35,6 +37,35 @@ function Invoke-ExternalCommand {
         exit 1
     }
     return $output
+}
+
+function Invoke-ExternalCommandWithRetry {
+    param(
+        [Parameter(Mandatory=$true)][string]$FilePath,
+        [Parameter()][string[]]$Arguments = @(),
+        [Parameter(Mandatory=$true)][string]$What,
+        [Parameter(Mandatory=$true)][int]$MaxAttempts,
+        [Parameter(Mandatory=$true)][int]$DelaySeconds
+    )
+
+    for ($attempt = 1; $attempt -le $MaxAttempts; $attempt++) {
+        Write-Blue ("{0}: attempt {1}/{2}..." -f $What, $attempt, $MaxAttempts)
+        $output = & $FilePath @Arguments 2>&1
+        $exitCode = $LASTEXITCODE
+        if ($exitCode -eq 0) {
+            return $output
+        }
+
+        if ($output) { Write-Host ($output | Out-String) }
+        if ($attempt -lt $MaxAttempts) {
+            Write-Yellow ("{0} failed (exit {1}). Retrying in {2} seconds..." -f $What, $exitCode, $DelaySeconds)
+            Start-Sleep -Seconds $DelaySeconds
+            continue
+        }
+
+        Write-ErrorColored ("Failed: {0} after {1} attempts (exit {2}). Remote ACR build did not complete; rerun this script or inspect the Azure CLI and ACR task output." -f $What, $MaxAttempts, $exitCode)
+        exit $exitCode
+    }
 }
 
 function Get-CliOutputValue {
@@ -344,7 +375,7 @@ if ($buildMode -eq 'local') {
         $acrBuildArgs += @('--agent-pool',$env:ACR_TASK_AGENT_POOL)
     }
     $acrBuildArgs += '.'
-    Invoke-ExternalCommand -FilePath 'az' -Arguments $acrBuildArgs -What 'ACR remote build' | Out-Null
+    Invoke-ExternalCommandWithRetry -FilePath 'az' -Arguments $acrBuildArgs -What 'ACR remote build' -MaxAttempts $acrBuildMaxAttempts -DelaySeconds $acrBuildRetryDelaySeconds | Out-Null
     Write-Green 'Remote build completed.'
 }
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -16,11 +16,42 @@ label="gpt-rag"
 imageRepository="data-ingestion"
 appConfigKey="DATA_INGEST_APP_NAME"
 identitySuffix="dataingest"
+acr_build_max_attempts=3
+acr_build_retry_delay_seconds=30
 
 info() { echo -e "${BLUE}$*${NC}" >&2; }
 success() { echo -e "${GREEN}$*${NC}" >&2; }
 warn() { echo -e "${YELLOW}$*${NC}" >&2; }
 error() { echo -e "${RED}$*${NC}" >&2; }
+
+run_with_retry() {
+  local what="$1"
+  local max_attempts="$2"
+  local delay_seconds="$3"
+  shift 3
+
+  local attempt status
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    info "${what}: attempt ${attempt}/${max_attempts}..."
+    set +e
+    "$@"
+    status=$?
+    set -e
+
+    if [[ $status -eq 0 ]]; then
+      return 0
+    fi
+
+    if ((attempt < max_attempts)); then
+      warn "${what} failed (exit ${status}). Retrying in ${delay_seconds} seconds..."
+      sleep "$delay_seconds"
+      continue
+    fi
+
+    error "Failed: ${what} after ${max_attempts} attempts (exit ${status}). Remote ACR build did not complete; rerun this script or inspect the Azure CLI and ACR task output."
+    return "$status"
+  done
+}
 
 select_cli_value() {
   local expected="${1:-}"
@@ -303,7 +334,7 @@ else
     acr_build_args+=(--agent-pool "$ACR_TASK_AGENT_POOL")
   fi
   acr_build_args+=(.)
-  az "${acr_build_args[@]}"
+  run_with_retry "ACR remote build" "$acr_build_max_attempts" "$acr_build_retry_delay_seconds" az "${acr_build_args[@]}"
   success "Remote build completed."
 fi
 


### PR DESCRIPTION
## Purpose
- Remove the ingestion image frontend build dependency on Docker Hub by switching the Node build stage to Microsoft Container Registry.
- Add bounded, visible retry behavior around remote `az acr build` in both deploy scripts.

## Target branch
- `develop`

## Validation
- PowerShell parser validation passed for `scripts/deploy.ps1`.
- `bash -n scripts/deploy.sh` passed using Git Bash.
- `git -c core.whitespace=cr-at-eol diff --check` passed.

## Validation gaps
- `docker build --check --file Dockerfile .` was attempted but Docker Desktop/Linux engine was not running in this workspace.
- Live ACR build was not run to avoid deploying/building against a shared Azure environment without an explicit validation target.